### PR TITLE
Update Dockerfile.saichallenger-client to Fix "ModuleNotFoundError: No module named 'sai_thrift'"

### DIFF
--- a/dash-pipeline/dockerfiles/Dockerfile.saichallenger-client
+++ b/dash-pipeline/dockerfiles/Dockerfile.saichallenger-client
@@ -11,15 +11,15 @@ ADD SAI/rpc/saithrift-0.9.tar.gz /
 
 # Install the python libraries
 RUN cd /saithrift-0.9 && \
-        python3 setup.py install && \
+        pip3 install . && \
     cd / && \
         rm -rf saithrift-0.9 &&\
     cd thrift-0.11.0 && \
-        python3 setup.py install && \
+        pip3 install . && \
     cd / &&\
         rm -rf thrift-0.11.0 && \
     cd /SAI/test/ptf && \
-        python3 setup.py install && \
+        pip3 install . && \
     ln -s ${DASH_PATH}/test/test-cases/scale/saic ${SAI_CHALLENGER_PATH}/dash_tests
 
 CMD ["/usr/bin/supervisord"]


### PR DESCRIPTION
Fixing below error
```
/usr/local/lib/python3.9/dist-packages/saichallenger/common/sai_client/sai_thrift_client/sai_thrift_client.py:8: in <module>
    from saichallenger.common.sai_client.sai_thrift_client.sai_thrift_utils import *
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    import re
    from itertools import zip_longest
    import ipaddress
    import json
    > from sai_thrift import sai_headers
    E   ModuleNotFoundError: No module named 'sai_thrift'
```

**"python3 setup.py install"** CHANGED to **"pip3 install ."** in Dockerfile.saichallenger-client.
**python3 setup.py install** , installes files in /usr/lib/python3.9/**site-packages**/  which is not in sys.path
**pip3 install .l** , installed it in /usr/local/lib/python3.9/**dist-packages**// which is in sys.apth
